### PR TITLE
truncate long ip addresses (ipv6)

### DIFF
--- a/peers.py
+++ b/peers.py
@@ -48,7 +48,12 @@ def draw_peers(state):
                         # syncnodes are outgoing only
                         win_peers.addstr(index-offset, 1, 'S')
 
-                win_peers.addstr(index-offset, 3, peer['addr'].replace(".onion","").replace(":8333","").replace(":18333","")[:21])
+                addr_str = peer['addr'].replace(".onion","").replace(":8333","").replace(":18333","").strip("[").strip("]")
+
+                # truncate long ip addresses (ipv6)
+                addr_str = (addr_str[:17] + '...') if len(addr_str) > 20 else addr_str
+
+                win_peers.addstr(index-offset, 3, addr_str)
                 win_peers.addstr(index-offset, 24, peer['subver'].strip("/").replace("Satoshi:","Sat")[:10])
 
                 mbrecv = "% 7.1f" % ( float(peer['bytesrecv']) / 1048576 )


### PR DESCRIPTION
ipv6 addresses (and maybe onion addresses) are too long to fit into the peers window.

this patch truncates long addresses with `...`

![screenshot-7](https://cloud.githubusercontent.com/assets/6561620/5533549/c3b7aff6-8a4a-11e4-8212-85529fd2e6d4.png)
